### PR TITLE
Fix the never-exports test for machines with older LWP::UserAgent

### DIFF
--- a/t/never-exports.t
+++ b/t/never-exports.t
@@ -17,13 +17,13 @@ use Test::Needs {
 subtest 'with version' => sub {
     my $pi = source2pi(
         'test-data/with-version.pl',
-        'use LWP::UserAgent 6.49;',
+        'use LWP::UserAgent 5.00;',
     );
 
     ok( !$pi->_is_ignored, '_is_ignored' );
     is(
         $pi->formatted_ppi_statement,
-        'use LWP::UserAgent 6.49 ();',
+        'use LWP::UserAgent 5.00 ();',
         'formatted_ppi_statement'
     );
 


### PR DESCRIPTION
Sandbox tries to evaluate the include, but if the installed version is too old, it fails and we get undef instead of an PPI object from $doc->includes->[0].

Require the version 5.00 which is guaranteed to be installed as it's required in Test::Need.