### PR TITLE
Allow PPI::Statement::Expression in hash key

### DIFF
--- a/t/hash-key-expression.t
+++ b/t/hash-key-expression.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use TestHelper qw( file2includes source2pi );
+use Test::More import => [qw( done_testing is )];
+use Test::Needs qw( HTTP::Status );
+
+my @includes = file2includes('test-data/hash-key-expression.pl');
+
+my $e = source2pi(
+    'test-data/hash-key-expression.pl', undef,
+    { include => $includes[2] }
+);
+
+is(
+    $e->formatted_ppi_statement,
+    'use HTTP::Status qw( is_info );',
+    'recognizes is_info as an imported symbol'
+);
+
+done_testing;

--- a/t/hash-unquoted-key.t
+++ b/t/hash-unquoted-key.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use TestHelper qw( file2includes source2pi );
+use Test::More import => [qw( done_testing is )];
+use Test::Needs qw( HTTP::Status );
+
+my @includes = file2includes('test-data/hash-unquoted-key.pl');
+
+my $e = source2pi(
+    'test-data/hash-unquoted-key.pl', undef,
+    { include => $includes[2] }
+);
+
+is(
+    $e->formatted_ppi_statement,
+    'use HTTP::Status ();',
+    'recognizes is_info as a word representing a string'
+);
+
+done_testing;

--- a/test-data/hash-key-expression.pl
+++ b/test-data/hash-key-expression.pl
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+
+use HTTP::Status qw(is_info);
+
+my %foo;
+my $code = 100;
+$foo{ is_info $code } = 'bar';

--- a/test-data/hash-unquoted-key.pl
+++ b/test-data/hash-unquoted-key.pl
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use HTTP::Status ();
+
+my %foo;
+$foo{is_info} = 1;


### PR DESCRIPTION
Originally, I was playing around with subroutine attributes and encounter an issue with the following code.

Before applying perlimports.
```
package MyPackage;
use Scalar::Util qw( refaddr );

my %attrs;

sub MODIFY_CODE_ATTRIBUTES {
	my ( $package, $subref, @attrs ) = @_;

	#my $addr = refaddr $subref;    # OK ─┐
	#$attrs{$addr} = \@attrs;       # ────┘

	#$attrs{ refaddr($subref) } = \@attrs;    # OK

	$attrs{ refaddr $subref } = \@attrs;    # Doesn't recognize refaddr as a Scalar::Util exported symbol

	return;
}

sub main : FOO {
	print "BAR";
}

1;
```

After applying perlimports.
```
package MyPackage;
use Scalar::Util ();

my %attrs;

sub MODIFY_CODE_ATTRIBUTES {
	my ( $package, $subref, @attrs ) = @_;

	#my $addr = refaddr $subref;    # OK ─┐
	#$attrs{$addr} = \@attrs;       # ────┘

	#$attrs{ refaddr($subref) } = \@attrs;    # OK

	$attrs{ refaddr $subref } = \@attrs;    # Doesn't recognize refaddr as a Scalar::Util exported symbol

	return;
}

sub main : FOO {
	print "BAR";
}

1;
```