### PR TITLE
Don't log a non-JSON message to STDERR on linting success when --json is enabled

### DIFF
--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -482,10 +482,10 @@ FILENAME:
                     return $pi_doc->linter_success;
                 }
             );
-            if ($linter_success) {
+            if ( $linter_success && !$self->_json ) {
                 $logger->error( $filename . ' OK' );
             }
-            else {
+            elsif ( !$linter_success ) {
                 $exit_code = 1;
             }
             next FILENAME;

--- a/precious.toml
+++ b/precious.toml
@@ -40,6 +40,7 @@ cmd = [ "perl", "-Ilib", "script/perlimports" ]
 lint_flags = ["--lint" ]
 tidy_flags = ["-i" ]
 ok_exit_codes = 0
+ignore_stderr = [".* OK"]
 
 [commands.perltidy]
 type = "both"

--- a/t/cli.t
+++ b/t/cli.t
@@ -174,6 +174,22 @@ subtest '--lint success' => sub {
     is( $exit,   0,   'exit code is success' );
 };
 
+subtest '--lint --json success' => sub {
+    local @ARGV = (
+        '--lint',
+        '--json',
+        '--no-config-file',
+        '-f' => 'test-data/lint-success.pl',
+    );
+    my $cli = App::perlimports::CLI->new;
+    my ( $stdout, $stderr, $exit ) = capture {
+        $cli->run;
+    };
+    is( $stderr, q{}, 'success message on STDERR' );
+    is( $stdout, q{}, 'no STDOUT' );
+    is( $exit,   0,   'exit code is success' );
+};
+
 subtest '--lint failure import args' => sub {
     local @ARGV = (
         '--lint',


### PR DESCRIPTION
The message on STDERR was breaking nvim-lint and it's also weird.
