### PR TITLE
Don't treat locally defined subs as importable symbols

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
+    - Don't treat locally defined subs as importable symbols (GH#110) (Olaf
+      Alders). Reported by Glenn Rice.
 
 0.000053  2024-01-13 20:12:59Z
     - Don't log a non-JSON message to STDERR on linting success when --json is

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -340,7 +340,8 @@ sub _build_imports {
                 $self->_document->my_own_inspector->explicit_export_names
             )
         ) {
-            if ( $self->_is_importable($symbol) ) {
+            if ( $self->_is_importable($symbol)
+                && !$self->_document->is_sub_name("$symbol") ) {
                 $found{$symbol} = 1;
             }
         }

--- a/t/locally-defined-sub.t
+++ b/t/locally-defined-sub.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use lib 't/lib', 'test-data/lib';
+
+use Test::Differences qw( eq_or_diff );
+use TestHelper        qw( doc );
+use Test::More import => [qw( done_testing )];
+
+my ( $doc, $log ) = doc(
+    filename => 'test-data/lib/Local/Round.pm', preserve_unused => 0,
+);
+
+my $expected = <<'END';
+package Local::Round;
+use parent 'Exporter';
+
+use strict;
+use warnings;
+
+use Math::Round qw( nearest );
+our @EXPORT_OK = qw(round);
+
+sub round {
+    my ( $number, $places ) = @_;
+    return nearest( 10**-$places, $number );
+}
+
+1;
+END
+
+eq_or_diff(
+    $doc->tidied_document,
+    $expected,
+    'locally defined sub is not ignored'
+);
+
+done_testing();

--- a/test-data/lib/Local/Round.pm
+++ b/test-data/lib/Local/Round.pm
@@ -1,0 +1,15 @@
+package Local::Round;
+use parent 'Exporter';
+
+use strict;
+use warnings;
+
+use Math::Round qw( nearest );
+our @EXPORT_OK = qw(round);
+
+sub round {
+    my ( $number, $places ) = @_;
+    return nearest( 10**-$places, $number );
+}
+
+1;

--- a/test-needs-cpanfile
+++ b/test-needs-cpanfile
@@ -14,6 +14,7 @@ on 'test' => sub {
     requires 'Lingua::EN::Inflect';
     requires 'List::AllUtils' => 0;
     requires 'LWP::UserAgent' => '6.49';
+    requires 'Math::Round' => '0.08';
     requires 'MetaCPAN::Moose' => 0;
     requires 'Mojo' => 0 if "$]" >= 5.016000;
     requires 'Moose' => 0;


### PR DESCRIPTION
Otherwise we have the issue where:

```perl
package Round;
use parent 'Exporter';

use strict;
use warnings;

use Math::Round qw(nearest);
our @EXPORT_OK = qw(round);

sub round {
    my ( $number, $places ) = @_;
    return nearest( 10**-$places, $number );
}

1;
```

gets an import changed to:

```perl
use Math::Round qw( nearest round );
```

Fixes #109
