### PR TITLE
Add TODO test for detecting tied packages

### DIFF
--- a/t/tie.t
+++ b/t/tie.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Path::Tiny qw( path );
+use TestHelper qw( doc );
+use Test::More import => [qw( done_testing is $TODO )];
+
+my $filename = 'test-data/tie.pl';
+my ($doc) = doc(
+    filename        => $filename,
+    preserve_unused => 0,
+);
+
+TODO: {
+    local $TODO = 'Cannot yet see packages used by tie';
+    is( $doc->tidied_document, path($filename)->slurp, 'tie observed' );
+}
+
+done_testing();

--- a/test-data/tie.pl
+++ b/test-data/tie.pl
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+
+use Tie::SubstrHash ();
+
+tie my %hash, 'Tie::SubstrHash', 1, 1, 1;


### PR DESCRIPTION
Currently, a package is believed to be unused if it is only used in a `tie` statement.