### PR TITLE
Add an .editorconfig file, to describe how code should be indented

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,3 @@ indent_size = 4
 
 [*.yml]
 indent_size = 2
-
-[cpanfile]
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,18 +10,8 @@ trim_trailing_whitespace = true
 charset = utf-8
 indent_size = 4
 
-[*.{html}]
-charset = utf-8
+[*.yml]
 indent_size = 2
-
-[*.{json}]
-indent_size = 3
-
-[*.{yaml}]
-indent_size = 2
-
-[Makefile]
-indent_style = tab
 
 [cpanfile]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{PL,pl,pm,t,toml}]
+charset = utf-8
+indent_size = 4
+
+[*.{html}]
+charset = utf-8
+indent_size = 2
+
+[*.{json}]
+indent_size = 3
+
+[*.{yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[cpanfile]
+indent_size = 2


### PR DESCRIPTION
This matches what `perltidy` is configured to do, where applicable.

Many text editors support being configured with this.  https://editorconfig.org/