### PR TITLE
add option to skip outputting empty import lists in use statements

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
+    - Add experimental --skip-empty-imports flag, to allow following style
+      guides that do not want an empty `qw()` import list in use statements.
+      (GH#118) (Thomas Lamprecht)
 
 0.000057  2025-04-30 12:12:23Z
     - Update test expectations for MooseX::Types::Moose 0.51 (GH#122) (Olaf

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -191,6 +191,11 @@ sub _build_args {
         ],
         [],
         [
+            'skip-empty-imports!',
+            'Skip empty imports: Foo qw(); vs Foo;. Defaults to false',
+        ],
+        [],
+        [
             'read-stdin',
             'Read statements to process from STDIN rather than the supplied file.',
         ],
@@ -266,6 +271,7 @@ sub _build_config {
         log_level
         never_export_modules_filename
         padding
+        skip_empty_imports
         preserve_duplicates
         preserve_unused
         tidy_whitespace
@@ -450,6 +456,7 @@ sub run {
         lint                => $self->_lint,
         logger              => $logger,
         padding             => $self->_config->padding,
+        skip_empty_imports  => $self->_config->skip_empty_imports,
         preserve_duplicates => $self->_config->preserve_duplicates,
         preserve_unused     => $self->_config->preserve_unused,
         tidy_whitespace     => $self->_config->tidy_whitespace,

--- a/lib/App/perlimports/Config.pm
+++ b/lib/App/perlimports/Config.pm
@@ -111,6 +111,13 @@ has padding => (
     default => 1,
 );
 
+has skip_empty_imports => (
+    is      => 'ro',
+    isa     => Bool,
+    lazy    => 1,
+    default => 0,
+);
+
 has preserve_duplicates => (
     is      => 'ro',
     isa     => Bool,
@@ -230,3 +237,4 @@ padding                         = true
 preserve_duplicates             = false
 preserve_unused                 = false
 tidy_whitespace                 = true
+skip_empty_imports              = false

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -170,6 +170,13 @@ has _padding => (
     default  => 1,
 );
 
+has _skip_empty_imports => (
+    is       => 'ro',
+    isa      => Bool,
+    init_arg => 'skip_empty_imports',
+    default  => 0,
+);
+
 has ppi_document => (
     is      => 'ro',
     isa     => Object,
@@ -897,7 +904,8 @@ INCLUDE:
             logger           => $self->logger,
             original_imports => $self->original_imports->{ $include->module },
             pad_imports      => $self->_padding,
-            tidy_whitespace  => $self->_tidy_whitespace,
+            skip_empty_imports => $self->_skip_empty_imports,
+            tidy_whitespace    => $self->_tidy_whitespace,
         );
         my $elem;
         try {

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -128,6 +128,13 @@ has _pad_imports => (
     default  => sub { 1 },
 );
 
+has _skip_empty_imports => (
+    is       => 'ro',
+    isa      => Bool,
+    init_arg => 'skip_empty_imports',
+    default  => sub { 0 },
+);
+
 has _tidy_whitespace => (
     is       => 'ro',
     isa      => Bool,
@@ -464,11 +471,10 @@ sub _build_formatted_ppi_statement {
     if (   $self->_will_never_export
         || $self->_is_translatable
         || !@{ $self->_imports } ) {
+        my $template
+            = $self->_skip_empty_imports() ? 'use %s%s;' : 'use %s%s ();';
         return $self->_maybe_get_new_include(
-            sprintf(
-                'use %s%s ();', $self->module_name, $maybe_module_version
-            )
-        );
+            sprintf( $template, $self->module_name, $maybe_module_version ) );
     }
 
     my $statement;

--- a/script/perlimports
+++ b/script/perlimports
@@ -425,6 +425,21 @@ parentheses.
     # --no-padding
     use Foo qw(bar baz);
 
+=head2 --[no-]skip-empty-imports
+
+C<--skip-empty-imports> is disabled by default. This means that empty import
+statements will always get added to use statements. This setting skips adding
+a import stanza if there is nothing to import.
+
+    # --no-skip-empty-imports
+    use Foo qw();
+
+The C<--skip-empty-imports> arg allows you to disable outputting an empty
+import list.
+
+    # --skip-empty-imports
+    use Foo;
+
 =head2 --[no-]tidy-whitespace
 
 C<--tidy-whitespace> is enabled by default. This means that use statements will

--- a/t/cli-args.t
+++ b/t/cli-args.t
@@ -39,6 +39,7 @@ EOF
         '--log-level'    => 'info',
         '--no-cache',
         '--no-padding',
+        '--skip-empty-imports',
         '--no-preserve-duplicates',
         '--no-preserve-unused',
         '--no-tidy-whitespace',
@@ -70,6 +71,7 @@ EOF
         'never_export'
     );
     is( $c->padding,             0, 'padding' );
+    is( $c->skip_empty_imports,  1, 'skip_empty_imports' );
     is( $c->preserve_duplicates, 0, 'preserve_duplicates' );
     is( $c->tidy_whitespace,     0, 'tidy_whitespace' );
 };

--- a/t/cli.t
+++ b/t/cli.t
@@ -454,6 +454,50 @@ EOF
     is( $stderr, q{},       'no STDERR' );
 };
 
+subtest '--skip-empty-imports' => sub {
+    my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Carp;
+use Data::Dumper;
+use POSIX;
+EOF
+
+    local @ARGV = (
+        '--no-config-file',
+        '--skip-empty-imports',
+        '-f' => 'test-data/original-imports.pl',
+    );
+    my $cli = App::perlimports::CLI->new;
+    my ( $stdout, $stderr ) = capture { $cli->run };
+    is( $stderr, q{},       'no STDERR' );
+    is( $stdout, $expected, 'stdout' );
+    is( $stderr, q{},       'no STDERR' );
+};
+
+subtest '--no-skip-empty-imports' => sub {
+    my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Carp ();
+use Data::Dumper ();
+use POSIX ();
+EOF
+
+    local @ARGV = (
+        '--no-config-file',
+        '--no-skip-empty-imports',
+        '-f' => 'test-data/original-imports.pl',
+    );
+    my $cli = App::perlimports::CLI->new;
+    my ( $stdout, $stderr ) = capture { $cli->run };
+    is( $stderr, q{},       'no STDERR' );
+    is( $stdout, $expected, 'stdout' );
+    is( $stderr, q{},       'no STDERR' );
+};
+
 subtest '--stdout' => sub {
     my $expected = <<'EOF';
 use strict;


### PR DESCRIPTION
This adds an option flag that, when enabled, causes perlimports to stop outputting empty import lists for use statements where there is no symbol to be imported.

While some projects and people want empty import lists to increase clarity and prevent the used module from having default exports in the future, others see them as unnecessary visual noise and would like to avoid them.

The CLI option is named `--skip-empty-imports`, and the configuration option is named `skip_empty_imports`. Both default to false, maintaining the current behavior that provides more deterministic clarity and future-proofs against export changes in the used modules.

Thanks to the existing code infrastructure, the implementation is relatively straightforward. We just add new options and wire them up so that they are available in the Include module when outputting. Since there is already a dedicated code branch for modules that never export or from which nothing is imported, we can modify the output format string template there to differentiate between the respective values of the new skip_empty_imports flag.

Add two tests to ensure that enabling and disabling explicitly work. Reuse the existing original-imports.pl test data module, as it is a fitting test asset.

Closes: #118

Open questions/tasks:
- In https://github.com/perl-ide/App-perlimports/issues/118#issuecomment-2828701056 it was mentioned to "flag it as beta/experimental". I checked the git history and found the commits adding the `--range-begin` and `--range-end` flags, and there the experimental status was only mentioned in the respective entry for the Changes file (ref commit e412e9ca228e009dad6bc0cfb651f823ee5716fb), so I opted for doing the same thing. Is that OK, or should I add other experimental markings somewhere?
- Is the CLI option name `--skip-empty-imports` and the config property name `skip_empty_imports` OK as is?
- Text in docs and changes might do well with another typo/grammar check as I'm not a native English speaker.
- Anything else I should evaluate or test to add confidence to the implementation?

And FWICT from implementing this my available time should be more than enough to stick around for bug fixes, albeit–for full transparency–I might need a few days, and seldomly even one or two weeks to respond, depending on work crunch/time-off/etc.